### PR TITLE
feat: Create Logs SDK LoggerProvider

### DIFF
--- a/logs_sdk/Gemfile
+++ b/logs_sdk/Gemfile
@@ -7,3 +7,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'opentelemetry-api', path: '../api'
+gem 'opentelemetry-logs-api', path: '../logs_api'
+gem 'opentelemetry-sdk', path: '../sdk'
+gem 'opentelemetry-test-helpers', path: '../test_helpers'

--- a/logs_sdk/lib/opentelemetry-logs-sdk.rb
+++ b/logs_sdk/lib/opentelemetry-logs-sdk.rb
@@ -4,5 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry'
+require 'opentelemetry/sdk'
 require 'opentelemetry/sdk/logs'
-require 'opentelemetry/sdk/logs/version'

--- a/logs_sdk/lib/opentelemetry/sdk/logs.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs.rb
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require_relative 'logs/version'
+require_relative 'logs/logger'
+require_relative 'logs/logger_provider'
 
 module OpenTelemetry
   module SDK

--- a/logs_sdk/lib/opentelemetry/sdk/logs.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs.rb
@@ -7,6 +7,8 @@
 require_relative 'logs/version'
 require_relative 'logs/logger'
 require_relative 'logs/logger_provider'
+require_relative 'logs/log_record_processor'
+require_relative 'logs/export'
 
 module OpenTelemetry
   module SDK

--- a/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
@@ -7,20 +7,14 @@
 module OpenTelemetry
   module SDK
     module Logs
-      # The Export module contains the built-in exporters and log record
-      # processors for the OpenTelemetry reference implementation.
+      # The export module contains result codes for LoggerProvider#force_flush
+      # and LoggerProvider#shutdown
       module Export
-        # Result codes for the LoggerProvider#force_flush and
-        # LoggerProvider#shutdown methods.
-
         # The operation finished successfully.
         SUCCESS = 0
 
         # The operation finished with an error.
         FAILURE = 1
-
-        # Additional result code for the LoggerProvider#force_flush and
-        # LoggerProvider#shutdown methods.
 
         # The operation timed out.
         TIMEOUT = 2

--- a/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
@@ -10,7 +10,8 @@ module OpenTelemetry
       # The Export module contains the built-in exporters and log record
       # processors for the OpenTelemetry reference implementation.
       module Export
-        # Result codes for the LogRecordExporter#export method and the LogRecordProcessor#force_flush and LogRecordProcessor#shutdown methods.
+        # Result codes for the LoggerProvider#force_flush and
+        # LoggerProvider#shutdown methods.
 
         # The operation finished successfully.
         SUCCESS = 0
@@ -18,7 +19,8 @@ module OpenTelemetry
         # The operation finished with an error.
         FAILURE = 1
 
-        # Additional result code for the LogRecordProcessor#force_flush and LogRecordProcessor#shutdown methods.
+        # Additional result code for the LoggerProvider#force_flush and
+        # LoggerProvider#shutdown methods.
 
         # The operation timed out.
         TIMEOUT = 2

--- a/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # The Export module contains the built-in exporters and log record
+      # processors for the OpenTelemetry reference implementation.
+      module Export
+        # Result codes for the LogRecordExporter#export method and the LogRecordProcessor#force_flush and LogRecordProcessor#shutdown methods.
+
+        # The operation finished successfully.
+        SUCCESS = 0
+
+        # The operation finished with an error.
+        FAILURE = 1
+
+        # Additional result code for the LogRecordProcessor#force_flush and LogRecordProcessor#shutdown methods.
+
+        # The operation timed out.
+        TIMEOUT = 2
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # 
+      class LogRecordProcessor
+        def shutdown(timeout: nil)
+          # TODO: implement
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module SDK
     module Logs
-      # 
+      # Presently no-op LogRecordProcessor
       class LogRecordProcessor
         def shutdown(timeout: nil)
           # TODO: implement

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -12,6 +12,10 @@ module OpenTelemetry
         def shutdown(timeout: nil)
           # TODO: implement
         end
+
+        def force_flush(timeout: nil)
+          # TODO: implement
+        end
       end
     end
   end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -7,18 +7,19 @@
 module OpenTelemetry
   module SDK
     module Logs
-      # {OpenTelemetry::SDK::Logs::Logger} is the SDK implementation of
-      # {OpenTelemetry::Logs::Logger}
+      # The SDK implementation of OpenTelemetry::Logs::Logger
       class Logger < OpenTelemetry::Logs::Logger
         attr_reader :instrumentation_scope, :logger_provider
 
         # @api private
         #
-        # Returns a new {OpenTelemetry::SDK::Logs::Logger} instance.
+        # Returns a new {OpenTelemetry::SDK::Logs::Logger} instance. This should
+        # not be called directly. New loggers should be created using
+        # {LoggerProvider#logger}.
         #
         # @param [String] name Instrumentation package name
         # @param [String] version Instrumentation package version
-        # @param [LoggerProvider] logger_provider LoggerProvider that
+        # @param [LoggerProvider] logger_provider The {LoggerProvider} that
         #   initialized the logger
         #
         # @return [OpenTelemetry::SDK::Logs::Logger]

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       # {OpenTelemetry::SDK::Logs::Logger} is the SDK implementation of
       # {OpenTelemetry::Logs::Logger}
       class Logger < OpenTelemetry::Logs::Logger
-        attr_reader :instrumentation_scope
+        attr_reader :instrumentation_scope, :logger_provider
 
         # @api private
         #

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -7,7 +7,8 @@
 module OpenTelemetry
   module SDK
     module Logs
-      # {OpenTelemetry::SDK::Logs::Logger} is the SDK implementation of {OpenTelemetry::Logs::Logger}
+      # {OpenTelemetry::SDK::Logs::Logger} is the SDK implementation of
+      # {OpenTelemetry::Logs::Logger}
       class Logger < OpenTelemetry::Logs::Logger
         attr_reader :instrumentation_scope
 
@@ -17,8 +18,8 @@ module OpenTelemetry
         #
         # @param [String] name Instrumentation package name
         # @param [String] version Instrumentation package version
-        # @param [LoggerProvider] logger_provider LoggerProvider that initialized
-        #   the logger
+        # @param [LoggerProvider] logger_provider LoggerProvider that
+        #   initialized the logger
         #
         # @return [OpenTelemetry::SDK::Logs::Logger]
         def initialize(name, version, logger_provider)

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # {OpenTelemetry::SDK::Logs::Logger} is the SDK implementation of {OpenTelemetry::Logs::Logger}
+      class Logger < OpenTelemetry::Logs::Logger
+        attr_reader :instrumentation_scope
+
+        # @api private
+        #
+        # Returns a new {OpenTelemetry::SDK::Logs::Logger} instance.
+        #
+        # @param [String] name Instrumentation package name
+        # @param [String] version Instrumentation package version
+        # @param [LoggerProvider] logger_provider LoggerProvider that initialized
+        #   the logger
+        #
+        # @return [OpenTelemetry::SDK::Logs::Logger]
+        def initialize(name, version, logger_provider)
+          @instrumentation_scope = InstrumentationScope.new(name, version)
+          @logger_provider = logger_provider
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -14,6 +14,7 @@ module OpenTelemetry
 
         EMPTY_NAME_ERROR = 'LoggerProvider#logger called without '\
             'providing a logger name.'
+        FORCE_FLUSH_ERROR = 'unexpected error in OpenTelemetry::SDK::Logs::LoggerProvider#force_flush'
 
         # Returns a new {LoggerProvider} instance.
         #
@@ -118,7 +119,8 @@ module OpenTelemetry
 
             results.max || Export::SUCCESS
           end
-        rescue StandardError
+        rescue StandardError => e
+          OpenTelemetry.handle_error(exception: e, message: FORCE_FLUSH_ERROR)
           Export::FAILURE
         end
       end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # {LoggerProvider} is the SDK implementation of
+      # {OpenTelemetry::Logs::LoggerProvider}.
+      class LoggerProvider < OpenTelemetry::Logs::LoggerProvider
+        EMPTY_NAME_ERROR = 'LoggerProvider#logger called without '\
+            'providing a logger name.'
+
+        # Returns a {OpenTelemetry::SDK::Logs::Logger} instance.
+        #
+        # @param [optional String] name Instrumentation package name
+        # @param [optional String] version Instrumentation package version
+        #
+        # @return [OpenTelemetry::SDK::Logs::Logger]
+        def logger(name = nil, version = nil)
+          name ||= ''
+          version ||= ''
+
+          OpenTelemetry.logger.warn(EMPTY_NAME_ERROR) if name.empty?
+
+          # registry mutex? is that needed here for async safety?
+          OpenTelemetry::SDK::Logs::Logger.new(name, version, self)
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -19,9 +19,9 @@ module OpenTelemetry
         # Returns a new LoggerProvider instance.
         #
         # @param [optional Resource] resource The resource to associate with
-        #   new LogRecords created by Loggers created by this LoggerProvider.
-        # @param [optional Array] log_record_processors The log record
-        #   processors to associate with this LoggerProvider.
+        #   new LogRecords created by {Logger}s created by this LoggerProvider.
+        # @param [optional Array] log_record_processors The
+        #   {LogRecordProcessor}s to associate with this LoggerProvider.
         #
         # @return [OpenTelemetry::SDK::Logs::LoggerProvider]
         def initialize(

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -10,8 +10,20 @@ module OpenTelemetry
       # {LoggerProvider} is the SDK implementation of
       # {OpenTelemetry::Logs::LoggerProvider}.
       class LoggerProvider < OpenTelemetry::Logs::LoggerProvider
+        attr_reader :resource
+
         EMPTY_NAME_ERROR = 'LoggerProvider#logger called without '\
             'providing a logger name.'
+
+        # Returns a new {LoggerProvider} instance.
+        #
+        # @param [optional Resource] resource The resource to associate with new
+        #   LogRecords created by Loggers created by this LoggerProvider
+        #
+        # @return [LoggerProvider]
+        def initialize(resource: OpenTelemetry::SDK::Resources::Resource.create)
+          @resource = resource
+        end
 
         # Returns a {OpenTelemetry::SDK::Logs::Logger} instance.
         #
@@ -25,7 +37,7 @@ module OpenTelemetry
 
           OpenTelemetry.logger.warn(EMPTY_NAME_ERROR) if name.empty?
 
-          # registry mutex? is that needed here for async safety?
+          # Q: @registry_mutex.synchronize invokes similar code within a block in the TracerProvider. Is that needed here for async safety?
           OpenTelemetry::SDK::Logs::Logger.new(name, version, self)
         end
       end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -87,6 +87,7 @@ module OpenTelemetry
               break [OpenTelemetry::SDK::Logs::Export::TIMEOUT] if remaining_timeout&.zero?
 
               # this needs an argument, but I'm having trouble passing the arg to the expect
+              # processor.shutdown(timeout: remaining_timeout)
               processor.shutdown
             end
 

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -76,9 +76,7 @@ module OpenTelemetry
         def shutdown(timeout: nil)
           @mutex.synchronize do
             if @stopped
-              OpenTelemetry.logger.warn(
-                'LoggerProvider#shutdown called multiple times.'
-              )
+              OpenTelemetry.logger.warn('LoggerProvider#shutdown called multiple times.')
               return OpenTelemetry::SDK::Logs::Export::FAILURE
             end
 

--- a/logs_sdk/opentelemetry-logs-sdk.gemspec
+++ b/logs_sdk/opentelemetry-logs-sdk.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'opentelemetry-api'
-  spec.add_dependency 'opentelemetry-logs-api'
-  spec.add_dependency 'opentelemetry-sdk'
+  spec.add_dependency 'opentelemetry-api', '~> 1.2'
+  spec.add_dependency 'opentelemetry-logs-api', '~> 0.1'
+  spec.add_dependency 'opentelemetry-sdk', '~> 1.3'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.19'

--- a/logs_sdk/opentelemetry-logs-sdk.gemspec
+++ b/logs_sdk/opentelemetry-logs-sdk.gemspec
@@ -29,13 +29,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-sdk'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 1.51.0'
-  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'minitest', '~> 5.19'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.4'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rubocop', '~> 1.56'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.17'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-logs-sdk/v#{OpenTelemetry::SDK::Logs::VERSION}/file.CHANGELOG.html"

--- a/logs_sdk/opentelemetry-logs-sdk.gemspec
+++ b/logs_sdk/opentelemetry-logs-sdk.gemspec
@@ -24,10 +24,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'opentelemetry-logs-api', '~> 0.1.0'
+  spec.add_dependency 'opentelemetry-api'
+  spec.add_dependency 'opentelemetry-logs-api'
+  spec.add_dependency 'opentelemetry-sdk'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 1.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/logs_sdk/test/.rubocop.yml
+++ b/logs_sdk/test/.rubocop.yml
@@ -1,24 +1,8 @@
-# inherit_from: .rubocop_todo.yml
+inherit_from: ../.rubocop.yml
 
-AllCops:
-  TargetRubyVersion: '3.0'
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-Metrics/AbcSize:
+Metrics/BlockLength:
   Enabled: false
 Metrics/LineLength:
   Enabled: false
-Metrics/MethodLength:
-  Max: 50
-Metrics/PerceivedComplexity:
-  Max: 30
-Metrics/CyclomaticComplexity:
-  Max: 20
-Metrics/ParameterLists:
-  Enabled: false
-Naming/FileName:
-  Exclude:
-    - 'lib/opentelemetry-logs-sdk.rb'
-Style/ModuleFunction:
+Metrics/AbcSize:
   Enabled: false

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Logs::LoggerProvider do
+  let(:logger_provider) { OpenTelemetry::SDK::Logs::LoggerProvider.new }
+
+  describe '#logger' do
+    it 'logs a warning if name is nil' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        logger_provider.logger(nil)
+        assert_match(
+          /#{OpenTelemetry::SDK::Logs::LoggerProvider::EMPTY_NAME_ERROR}/,
+          log_stream.string
+        )
+      end
+    end
+
+    it 'logs a warning if name is an empty string' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        logger_provider.logger('')
+        assert_match(
+          /#{OpenTelemetry::SDK::Logs::LoggerProvider::EMPTY_NAME_ERROR}/,
+          log_stream.string
+        )
+      end
+    end
+
+    it 'sets name to an empty string if nil' do
+      logger = logger_provider.logger(nil)
+      assert_equal(logger.instrumentation_scope.name, '')
+    end
+
+    it 'sets version to an empty string if nil' do
+      logger = logger_provider.logger('name', nil)
+      assert_equal(logger.instrumentation_scope.version, '')
+    end
+
+    it 'creates a new logger with the passed-in name and version' do
+      name = 'name'
+      version = 'version'
+      logger = logger_provider.logger(name, version)
+      assert_equal(logger.instrumentation_scope.name, name)
+      assert_equal(logger.instrumentation_scope.version, version)
+    end
+
+    it 'creates a new logger when name and version are missing' do
+      logger = logger_provider.logger
+      logger2 = logger_provider.logger
+
+      refute_same(logger, logger2)
+      assert_instance_of(OpenTelemetry::SDK::Logs::Logger, logger)
+    end
+  end
+end

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -120,7 +120,7 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
       mock_log_record_processor2.verify
     end
 
-    it 'only notifies the processor once' do
+    it 'subsequent shutdown attempts do not reach the processor' do
       mock_log_record_processor.expect(:shutdown, nil, timeout: nil)
 
       logger_provider.add_log_record_processor(mock_log_record_processor)

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -77,44 +77,49 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
 
   describe '#shutdown' do
     # TODO: Figure out why the argument isn't working on expect/in method
-    let(:processor) { OpenTelemetry::SDK::Logs::LogRecordProcessor.new }
-    let(:provider) do
-      OpenTelemetry::SDK::Logs::LoggerProvider.new(
-        log_record_processors: [processor]
-      )
-    end
+    let(:mock_log_record_processor) { Minitest::Mock.new }
 
     it 'logs a warning if called twice' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-        provider.shutdown
-        assert provider.instance_variable_get(:@stopped)
+        logger_provider.shutdown
+        assert logger_provider.instance_variable_get(:@stopped)
         assert_empty(log_stream.string)
-        provider.shutdown
+        logger_provider.shutdown
         assert_match(/calling .* multiple times/, log_stream.string)
       end
     end
 
     it 'sends shutdown to the processor' do
-      mock_span_processor = Minitest::Mock.new
-      mock_span_processor.expect(:shutdown, nil)
-      provider.add_log_record_processor(mock_span_processor)
-      provider.shutdown
-      mock_span_processor.verify
+      # mock_log_record_processor.expect(:shutdown, nil, [{timeout: nil}])
+      mock_log_record_processor.expect(:shutdown, nil)
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.shutdown
+      mock_log_record_processor.verify
     end
 
     it 'sends shutdown to multiple processors' do
-      mock_span_processor = Minitest::Mock.new
-      mock_span_processor2 = Minitest::Mock.new
-      mock_span_processor.expect(:shutdown, nil)
-      mock_span_processor2.expect(:shutdown, nil)
+      mock_log_record_processor2 = Minitest::Mock.new
+      # mock_log_record_processor.expect(:shutdown, nil, [{timeout: nil}])
+      # mock_log_record_processor2.expect(:shutdown, nil, [{timeout: nil}])
+      mock_log_record_processor.expect(:shutdown, nil)
+      mock_log_record_processor2.expect(:shutdown, nil)
 
-      provider.instance_variable_set(:@log_record_processors, [mock_span_processor, mock_span_processor2])
+      logger_provider.instance_variable_set(:@log_record_processors, [mock_log_record_processor, mock_log_record_processor2])
+      logger_provider.shutdown
 
-      provider.shutdown
-
-      mock_span_processor.verify
-      mock_span_processor2.verify
+      mock_log_record_processor.verify
+      mock_log_record_processor2.verify
     end
+
+    it 'only notifies the processor once' do
+      # mock_log_record_processor.expect(:shutdown, nil, [{timeout: nil}])
+      mock_log_record_processor.expect(:shutdown, nil)
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.shutdown
+      logger_provider.shutdown
+      mock_log_record_processor.verify
+    end
+  end
 
     it 'only notifies the processor once' do
       mock_span_processor = Minitest::Mock.new

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -174,8 +174,7 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
     end
 
     it 'returns a failure code when an error is raised' do
-      OpenTelemetry::Common::Utilities.stub :maybe_timeout, -> { raise StandardError.new, 'fail' } do
-        logger_provider.add_log_record_processor(mock_log_record_processor)
+      OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
         assert_equal(OpenTelemetry::SDK::Logs::Export::FAILURE, logger_provider.force_flush)
       end
     end

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -19,10 +19,11 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
   end
 
   describe '#add_log_record_processor' do
-    it 'adds the processor to the providers processors' do
-      mock_span_processor = Minitest::Mock.new
+    let(:mock_log_record_processor) { Minitest::Mock.new }
+
+    it "adds the processor to the logger provider's processors" do
       assert_equal(0, logger_provider.instance_variable_get(:@log_record_processors).length)
-      logger_provider.add_log_record_processor(mock_span_processor)
+      logger_provider.add_log_record_processor(mock_log_record_processor)
       assert_equal(1, logger_provider.instance_variable_get(:@log_record_processors).length)
     end
   end
@@ -121,14 +122,28 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
     end
   end
 
-    it 'only notifies the processor once' do
-      mock_span_processor = Minitest::Mock.new
+  describe '#force_flush' do
+    let(:mock_log_record_processor)  { Minitest::Mock.new }
+    let(:mock_log_record_processor2) { Minitest::Mock.new }
 
-      mock_span_processor.expect(:shutdown, nil)
-      provider.add_log_record_processor(mock_span_processor)
-      provider.shutdown
-      provider.shutdown
-      mock_span_processor.verify
+    it 'notifies the log record processor' do
+      # mock_log_record_processor.expect(:force_flush, nil, [{timeout: nil}])
+      mock_log_record_processor.expect(:force_flush, nil)
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.force_flush
+      mock_log_record_processor.verify
+    end
+
+    it 'supports multiple log record processors' do
+      # mock_log_record_processor.expect(:force_flush, nil, [{timeout: nil}])
+      # mock_log_record_processor2.expect(:force_flush, nil, [{timeout: nil}])
+      mock_log_record_processor.expect(:force_flush, nil)
+      mock_log_record_processor2.expect(:force_flush, nil)
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.add_log_record_processor(mock_log_record_processor2)
+      logger_provider.force_flush
+      mock_log_record_processor.verify
+      mock_log_record_processor2.verify
     end
   end
 end

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -18,6 +18,15 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
     end
   end
 
+  describe '#add_log_record_processor' do
+    it 'adds the processor to the providers processors' do
+      mock_span_processor = Minitest::Mock.new
+      assert_equal(0, logger_provider.instance_variable_get(:@log_record_processors).length)
+      logger_provider.add_log_record_processor(mock_span_processor)
+      assert_equal(1, logger_provider.instance_variable_get(:@log_record_processors).length)
+    end
+  end
+
   describe '#logger' do
     it 'logs a warning if name is nil' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -9,6 +9,15 @@ require 'test_helper'
 describe OpenTelemetry::SDK::Logs::LoggerProvider do
   let(:logger_provider) { OpenTelemetry::SDK::Logs::LoggerProvider.new }
 
+  describe 'resource association' do
+    let(:resource) { OpenTelemetry::SDK::Resources::Resource.create('hi' => 1) }
+    let(:logger_provider) { OpenTelemetry::SDK::Logs::LoggerProvider.new(resource: resource) }
+
+    it 'allows a resource to be associated with the logger provider' do
+      assert_instance_of(OpenTelemetry::SDK::Resources::Resource, logger_provider.resource)
+    end
+  end
+
   describe '#logger' do
     it 'logs a warning if name is nil' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -26,17 +26,10 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
 
   describe '#add_log_record_processor' do
     it "adds the processor to the logger provider's processors" do
-      assert_equal(
-        0,
-        logger_provider.instance_variable_get(:@log_record_processors).length
-      )
+      assert_equal(0, logger_provider.log_record_processors.length)
 
       logger_provider.add_log_record_processor(mock_log_record_processor)
-
-      assert_equal(
-        1,
-        logger_provider.instance_variable_get(:@log_record_processors).length
-      )
+      assert_equal(1, logger_provider.log_record_processors.length)
     end
   end
 

--- a/logs_sdk/test/test_helper.rb
+++ b/logs_sdk/test/test_helper.rb
@@ -9,6 +9,8 @@ SimpleCov.start { enable_coverage :branch }
 SimpleCov.minimum_coverage 85
 
 require 'opentelemetry-logs-api'
+require 'opentelemetry-logs-sdk'
+require 'opentelemetry-test-helpers'
 require 'minitest/autorun'
 
 OpenTelemetry.logger = Logger.new(File::NULL)


### PR DESCRIPTION
Fulfills the [Logs SDK specs for Logger Provider](https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerprovider)

The Logger Provider has a lot of similarities with the already implemented Tracer Provider, as they have very similar specs.

* [Tracer Provider specs](https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracer-provider)
* [TracerProvider class](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb)